### PR TITLE
Update gatherComponentsData and findDirtyComponents for latest AFrame.

### DIFF
--- a/src/ComponentHelper.js
+++ b/src/ComponentHelper.js
@@ -8,16 +8,17 @@ module.exports.gatherComponentsData = function(el, schemaComponents) {
     var element = schemaComponents[i];
 
     if (typeof element === 'string') {
-      if (el.components.hasOwnProperty(element)) {
-        compsData[element] = AFRAME.utils.clone(el.getAttribute(element));
+      var rootComponentData = el.getAttribute(element);
+      if (rootComponentData !== null) {
+        compsData[element] = AFRAME.utils.clone(rootComponentData);
       }
     } else {
       var childKey = NAF.utils.childSchemaToKey(element);
       var child = element.selector ? el.querySelector(element.selector) : el;
       if (child) {
-        if (child.components.hasOwnProperty(element.component)) {
-          var attributeData = child.getAttribute(element.component);
-          var data = element.property ? attributeData[element.property] : attributeData;
+        var childComponentData = child.getAttribute(element.component);
+        if (childComponentData !== null) {
+          var data = element.property ? childComponentData[element.property] : childComponentData;
           compsData[childKey] = AFRAME.utils.clone(data);
         } else {
           // NAF.log.write('ComponentHelper.gatherComponentsData: Could not find component ' + element.component + ' on child ', child, child.components);
@@ -38,25 +39,32 @@ module.exports.findDirtyComponents = function(el, syncedComps, cachedData) {
 
     var isRoot = typeof schema === 'string';
     if (isRoot) {
-      var hasComponent = el.components.hasOwnProperty(schema)
-      if (!hasComponent) {
+      var rootComponentData = el.getAttribute(schema);
+      if (rootComponentData === null) {
         continue;
       }
+
       compKey = schema;
-      newCompData = el.getAttribute(schema);
+      newCompData = rootComponentData;
     }
     else {
       // is child
       var selector = schema.selector;
       var compName = schema.component;
       var propName = schema.property;
+
       var childEl = selector ? el.querySelector(selector) : el;
-      var hasComp = childEl && childEl.components.hasOwnProperty(compName);
-      if (!hasComp) {
+      if (!childEl) {
         continue;
       }
+
+      var childComponentData = childEl.getAttribute(compName);
+      if (childComponentData === null) {
+        continue;
+      }
+
       compKey = NAF.utils.childSchemaToKey(schema);
-      newCompData = childEl.getAttribute(compName);
+      newCompData = childComponentData;
       if (propName) {
         newCompData = newCompData[propName];
       }


### PR DESCRIPTION
This PR uses `el.getAttribute()` to check whether a component exists on a given element.

The latest AFrame removed position, rotation, scale, and visible components as default components. You can still get any of these properties from an entity by calling `getAttribute()` on an entity, but we can no longer expect them to always be in the `el.components` object.