### PR TITLE
Fix race condition

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -47,11 +47,11 @@ function getNetworkedEntity(entity) {
   return new Promise((resolve, reject) => {
     let curEntity = entity;
 
-    while(curEntity && !curEntity.hasAttribute("networked")) {
+    while(curEntity && curEntity.components && !curEntity.components.networked) {
       curEntity = curEntity.parentNode;
     }
 
-    if (!curEntity) {
+    if (!curEntity || !curEntity.components || !curEntity.components.networked) {
       return reject("Entity does not have and is not a child of an entity with the [networked] component ");
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,37 +70,29 @@ module.exports.getNetworkedEntity = getNetworkedEntity;
 module.exports.takeOwnership = function(entity) {
   let curEntity = entity;
 
-  while(curEntity && !curEntity.hasAttribute("networked")) {
+  while(curEntity && curEntity.components && !curEntity.components.networked) {
     curEntity = curEntity.parentNode;
   }
 
-  if (curEntity) {
-    if (!curEntity.components.networked) {
-      throw new Error("Entity with [networked] component not initialized.");
-    }
-
-    return curEntity.components.networked.takeOwnership();
+  if (!curEntity || !curEntity.components || !curEntity.components.networked) {
+    throw new Error("Entity does not have and is not a child of an entity with the [networked] component ");
   }
 
-  throw new Error("takeOwnership() must be called on an entity or child of an entity with the [networked] component.");
+  return curEntity.components.networked.takeOwnership();
 };
 
 module.exports.isMine = function(entity) {
   let curEntity = entity;
 
-  while(curEntity && !curEntity.hasAttribute("networked")) {
+  while(curEntity && curEntity.components && !curEntity.components.networked) {
     curEntity = curEntity.parentNode;
   }
 
-  if (curEntity) {
-    if (!curEntity.components.networked) {
-      throw new Error("Entity with [networked] component not initialized.");
-    }
-
-    return curEntity.components.networked.data.owner === NAF.clientId;
+  if (!curEntity || !curEntity.components || !curEntity.components.networked) {
+    throw new Error("Entity does not have and is not a child of an entity with the [networked] component ");
   }
 
-  throw new Error("isMine() must be called on an entity or child of an entity with the [networked] component.");
+  return curEntity.components.networked.data.owner === NAF.clientId;
 };
 
 module.exports.almostEqualVec3 = function(u, v, epsilon) {


### PR DESCRIPTION
In html:
  ```
<template id="foo" >
                <a-entity foo></a-entity>
            </template>
```
In javascript:
```
AFRAME.registerComponent("foo", {
  init() {
    NAF.utils.getNetworkedEntity(this.el).then(() => {
      console.log("FOO!");
    });
  }
});
  NAF.schemas.add({
    template: "#foo",
    components: ["position", "rotation"]
  });
```

Race condition:

  ```
const scene = AFRAME.scenes[0];

  const entity = document.createElement("a-entity");
  entity.setAttribute("networked", {template: "#foo" }); // no problem
  scene.appendChild(entity);

  const entity2 = document.createElement("a-entity");
  scene.appendChild(entity2);
  // wait for the entity to get added to the DOM
  window.setTimeout(() => {
    entity2.setAttribute("networked", { template: "#foo" }); // error
  }, 1000);
```

The bug happens when `getNetworkedEntity` looks for the `networked` component using `getAttribute("networked")`. In the case that the entity is already in the scene, `networked::init()` will run, then cause `foo::init()` to run. At that point even though `networked::init()` is running, it is not an attribute on the entity/element yet.

(The failure case only happens when the element has been attached to the dom because the component is initialized here : 
https://github.com/aframevr/aframe/blob/master/src/core/a-entity.js#L336
https://github.com/aframevr/aframe/blob/master/src/core/component.js#L50
https://github.com/aframevr/aframe/blob/master/src/core/component.js#L271

Causing `foo`'s `init` to run. But the component's `networked` attribute isn't added to the html element until afterward, here:
https://github.com/aframevr/aframe/blob/master/src/core/a-entity.js#L345)

When the element doesn't have time to get attached to the dom, then the component's attribute is added to the html element, and all is fine.)
