### PR TITLE
Only use interpolation buffers for relevant component data.

### DIFF
--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -393,12 +393,13 @@ AFRAME.registerComponent('networked', {
                      object3D: el.object3D,
                      componentNames: [componentName] };
       this.bufferInfos.push(bufferInfo);
+    } else {
+      var componentNames = bufferInfo.componentNames;
+      if (!componentNames.includes(componentName)){
+        componentNames.push(componentName);
+      }
     }
     var buffer = bufferInfo.buffer;
-    var componentNames = bufferInfo.componentNames;
-    if (!componentNames.includes(componentName)){
-      componentNames.push(componentName);
-    }
 
     switch(componentName) {
       case "position":

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -2,7 +2,7 @@
 var deepEqual = require('fast-deep-equal');
 var InterpolationBuffer = require('buffered-interpolation');
 var DEG2RAD = THREE.Math.DEG2RAD;
-var OBJECT3D_COMPONENTS = ["position", "rotation", "scale"];
+var OBJECT3D_COMPONENTS = ['position', 'rotation', 'scale'];
 
 function defaultRequiresUpdate() {
   let cachedData = null;
@@ -185,13 +185,13 @@ AFRAME.registerComponent('networked', {
         var object3D = bufferInfo.object3D;
         var componentNames = bufferInfo.componentNames;
         buffer.update(dt);
-        if (componentNames.includes("position")){
+        if (componentNames.includes('position')) {
           object3D.position.copy(buffer.getPosition());
         }
-        if (componentNames.includes("rotation")){
+        if (componentNames.includes('rotation')) {
           object3D.quaternion.copy(buffer.getQuaternion());
         }
-        if (componentNames.includes("scale")){
+        if (componentNames.includes('scale')) {
           object3D.scale.copy(buffer.getScale());
         }
       }
@@ -395,25 +395,25 @@ AFRAME.registerComponent('networked', {
       this.bufferInfos.push(bufferInfo);
     } else {
       var componentNames = bufferInfo.componentNames;
-      if (!componentNames.includes(componentName)){
+      if (!componentNames.includes(componentName)) {
         componentNames.push(componentName);
       }
     }
     var buffer = bufferInfo.buffer;
 
     switch(componentName) {
-      case "position":
+      case 'position':
         buffer.setPosition(this.bufferPosition.set(data.x, data.y, data.z));
         return;
-      case "rotation":
+      case 'rotation':
         this.conversionEuler.set(DEG2RAD * data.x, DEG2RAD * data.y, DEG2RAD * data.z);
         buffer.setQuaternion(this.bufferQuaternion.setFromEuler(this.conversionEuler));
         return;
-      case "scale":
+      case 'scale':
         buffer.setScale(this.bufferScale.set(data.x, data.y, data.z));
         return;
     }
-    NAF.log.error("Could not set value in interpolation buffer.", el, componentName, data, bufferInfo);
+    NAF.log.error('Could not set value in interpolation buffer.', el, componentName, data, bufferInfo);
   },
 
   removeLerp: function() {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -182,9 +182,16 @@ AFRAME.registerComponent('networked', {
         var interpolationBuffer = this.interpolationBuffers[i].buffer;
         var el = this.interpolationBuffers[i].el;
         interpolationBuffer.update(dt);
-        el.object3D.position.copy(interpolationBuffer.getPosition());
-        el.object3D.quaternion.copy(interpolationBuffer.getQuaternion());
-        el.object3D.scale.copy(interpolationBuffer.getScale());
+        var componentName = interpolationBuffer.componentName;
+        if (componentName === "position"){
+          el.object3D.position.copy(interpolationBuffer.getPosition());
+        }
+        else if (componentName === "rotation"){
+          el.object3D.quaternion.copy(interpolationBuffer.getQuaternion());
+        }
+        else if (componentName === "scale"){
+          el.object3D.scale.copy(interpolationBuffer.getScale());
+        }
       }
     }
   },
@@ -373,18 +380,19 @@ AFRAME.registerComponent('networked', {
   },
 
   updateComponent: function (el, componentName, data) {
-    if(!NAF.options.useLerp) {
+    const transformComponents = ["position", "rotation", "scale"]
+    if(!NAF.options.useLerp || !transformComponents.includes(componentName)) {
       el.setAttribute(componentName, data);
       return;
     }
 
     var buffer = null;
-    var interpolationBuffer = this.interpolationBuffers.find((item) => item.el === el);
+    var interpolationBuffer = this.interpolationBuffers.find((item) => item.el === el && item.componentName===componentName);
     if (!interpolationBuffer) {
       buffer = new InterpolationBuffer(InterpolationBuffer.MODE_LERP, 0.1);
-      this.interpolationBuffers.push({ buffer: buffer, el: el });
+      this.interpolationBuffers.push({ buffer: buffer, componentName: componentName, el: el });
     } else {
-      buffer = this.interpolationBuffers.find((item) => item.el === el).buffer;
+      buffer = interpolationBuffer.buffer;
     }
 
     switch(componentName) {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -2,6 +2,7 @@
 var deepEqual = require('fast-deep-equal');
 var InterpolationBuffer = require('buffered-interpolation');
 var DEG2RAD = THREE.Math.DEG2RAD;
+var OBJECT3D_COMPONENTS = ["position", "rotation", "scale"];
 
 function defaultRequiresUpdate() {
   let cachedData = null;
@@ -381,8 +382,7 @@ AFRAME.registerComponent('networked', {
   },
 
   updateComponent: function (el, componentName, data) {
-    const transformComponents = ["position", "rotation", "scale"]
-    if(!NAF.options.useLerp || !transformComponents.includes(componentName)) {
+    if(!NAF.options.useLerp || !OBJECT3D_COMPONENTS.includes(componentName)) {
       el.setAttribute(componentName, data);
       return;
     }

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -412,7 +412,7 @@ AFRAME.registerComponent('networked', {
         buffer.setScale(this.bufferScale.set(data.x, data.y, data.z));
         return;
     }
-    console.error("Could not set value in interpolation buffer.", el, componentName, data, bufferInfo);
+    NAF.log.error("Could not set value in interpolation buffer.", el, componentName, data, bufferInfo);
   },
 
   removeLerp: function() {


### PR DESCRIPTION
To see the bug, run the example page on mr-social-client/master before pulling in this change.

The bug manifests itself in a couple ways:
- If your schema says you'll sync `position`, `rotation`, or `scale`, then the `networked` component will read ALL of them from the interpolation buffer. 
- If your template has a child with any synced components, the `position`, `rotation`, and `scale` will be set to the default values every tick for the same reason. In the example page, this manifests itself in the following way:
The `.head` entity's `scale` will initialize to `{x: 0.45, y: 0.5, z: 0.5}` as per its attribute values declared in the `#avatar-template`.
The `networked` component will create an `InterpolationBuffer` for the `.head` entity in its first `networkUpdate` (via `updateComponents` -> `updateComponent`), even though the `.head` entity only wants to sync its `material.color`. 
On the first `tick` of the `networked` component, the `position`, `rotation`, and `scale` of the `interpolationBuffer` created for the `.head` entity will overwrite the value in the `head`'s `object3D`.
(Note that at this point, `headEntity.components.scale.data === {x: 0.45, y:0.5, z:0.5}` but `headEntity.object3D.scale === {x: 1, y: 1, z:1}`. It is scary that this is possible, but I suppose we are willing to take this risk to avoid calling `setAttribute`.)

This patch tries to fix the issues above.