### PR TITLE
Only update matrices when the networked object's transform changed.

### DIFF
--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -50,7 +50,8 @@ class NetworkEntities {
     var networkData = {
       template: entityData.template,
       owner: entityData.owner,
-      networkId: entityData.networkId
+      networkId: entityData.networkId,
+      matrixAutoUpdate: entityData.matrixAutoUpdate
     };
 
     entity.setAttribute('networked', networkData);

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -22,6 +22,7 @@ AFRAME.registerComponent('networked', {
     template: {default: ''},
     attachTemplateToLocal: { default: true },
 
+    matrixAutoUpdate: { default: false },
     networkId: {default: ''},
     owner: {default: ''},
   },
@@ -195,7 +196,7 @@ AFRAME.registerComponent('networked', {
           object3D.scale.copy(buffer.getScale());
           shouldUpdateMatrix = true;
         }
-        if (shouldUpdateMatrix) {
+        if (shouldUpdateMatrix && !this.data.matrixAutoUpdate) {
           object3D.updateMatrix();
         }
       }
@@ -310,6 +311,7 @@ AFRAME.registerComponent('networked', {
     syncData.parent = this.getParentId();
     syncData.components = components;
     syncData.isFirstSync = !!isFirstSync;
+    syncData.matrixAutoUpdate = data.matrixAutoUpdate;
     return syncData;
   },
 
@@ -393,7 +395,7 @@ AFRAME.registerComponent('networked', {
 
     var bufferInfo = this.bufferInfos.find((info) => info.object3D === el.object3D);
     if (!bufferInfo) {
-      el.object3D.matrixAutoUpdate = false;
+      el.object3D.matrixAutoUpdate = this.data.matrixAutoUpdate;
       bufferInfo = { buffer: new InterpolationBuffer(InterpolationBuffer.MODE_LERP, 0.1),
                      object3D: el.object3D,
                      lastPosition: new THREE.Vector3(),

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -142,7 +142,8 @@ suite('networked', function() {
           0: { x: 1, y: 2, z: 3 },
           1: { x: 4, y: 3, z: 2 }
         },
-        isFirstSync: false
+        isFirstSync: false,
+        matrixAutoUpdate: false
       };
 
       networked.init();
@@ -179,7 +180,8 @@ suite('networked', function() {
         components: {
           1: { x: 9, y: 8, z: 7 }
         },
-        isFirstSync: false
+        isFirstSync: false,
+        matrixAutoUpdate: false
       };
 
       networked.init();


### PR DESCRIPTION
Reduces the overhead in updating interpolated objects that have not moved since the last received transform.

- Set networked entities to not automatically update their matrices.
- Store the previous position, rotation, and scale per networked entity.
- Check the last position/rotation/scale and update their matrix if any properties have changed.