### PR TITLE
Emit adapter-ready event before connecting

### DIFF
--- a/src/components/networked-scene.js
+++ b/src/components/networked-scene.js
@@ -45,6 +45,7 @@ AFRAME.registerComponent('networked-scene', {
     var adapterName = this.data.adapter;
     var adapter = NAF.adapters.make(adapterName);
     NAF.connection.setNetworkAdapter(adapter);
+    this.el.emit('adapter-ready', adapter, false);
   },
 
   hasOnConnectFunction: function() {


### PR DESCRIPTION
This allows us to manipulate the adapter before `connect()` is called