### PR TITLE
Store and remove entities by creator

### DIFF
--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -137,8 +137,8 @@ class NetworkEntities {
   removeEntitiesOfClient(clientId) {
     var entityList = [];
     for (var id in this.entities) {
-      var entityOwner = NAF.utils.getNetworkOwner(this.entities[id]);
-      if (entityOwner == clientId) {
+      var entityCreator = NAF.utils.getCreator(this.entities[id]);
+      if (entityCreator === clientId) {
         let persists;
         const component = this.entities[id].getAttribute('networked');
         if (component && component.persistent) {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -28,6 +28,7 @@ AFRAME.registerComponent('networked', {
   },
 
   init: function() {
+    this.creator = null;
     this.OWNERSHIP_GAINED = 'ownership-gained';
     this.OWNERSHIP_CHANGED = 'ownership-changed';
     this.OWNERSHIP_LOST = 'ownership-lost';
@@ -167,6 +168,12 @@ AFRAME.registerComponent('networked', {
 
   isMine: function() {
     return this.data.owner === NAF.clientId;
+  },
+
+  update: function(oldData) {
+    if (this.creator === null && this.data.owner) {
+      this.creator = this.data.owner;
+    }
   },
 
   tick: function(time, dt) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,14 @@ module.exports.createHtmlNodeFromString = function(str) {
   return child;
 }
 
+module.exports.getCreator = function(el) {
+  var components = el.components;
+  if (components.hasOwnProperty('networked')) {
+    return components['networked'].creator;
+  }
+  return null;
+}
+
 module.exports.getNetworkOwner = function(el) {
   var components = el.components;
   if (components.hasOwnProperty('networked')) {

--- a/tests/unit/NetworkEntities.test.js
+++ b/tests/unit/NetworkEntities.test.js
@@ -337,7 +337,7 @@ suite('NetworkEntities', function() {
         scene.appendChild(el);
         entityList.push(el);
       }
-      this.stub(naf.utils, 'getNetworkOwner').returns(entityData.owner);
+      this.stub(naf.utils, 'getCreator').returns(entityData.owner);
 
       var removedEntities = entities.removeEntitiesOfClient(entityData.owner);
 


### PR DESCRIPTION
- Adds a `creator` field to the `networked` component. The creator is set to the first owner.
- Adds a `getCreator` method to `utls`.
- Change `removeEntitiesOfClient` to remove entities by creator instead of owner.