### PR TITLE
Add an option to ignore first sync messages from specified sources

### DIFF
--- a/src/NetworkConnection.js
+++ b/src/NetworkConnection.js
@@ -191,9 +191,9 @@ class NetworkConnection {
         || dataType == ReservedDataType.Remove;
   }
 
-  receivedData(fromClientId, dataType, data) {
+  receivedData(fromClientId, dataSource, dataType, data, source) {
     if (this.dataChannelSubs.hasOwnProperty(dataType)) {
-      this.dataChannelSubs[dataType](fromClientId, dataType, data);
+      this.dataChannelSubs[dataType](fromClientId, dataType, data, source);
     } else {
       NAF.log.error('NetworkConnection@receivedData: ' + dataType + ' has not been subscribed to yet. Call subscribeToDataChannel()');
     }

--- a/src/NetworkConnection.js
+++ b/src/NetworkConnection.js
@@ -191,7 +191,7 @@ class NetworkConnection {
         || dataType == ReservedDataType.Remove;
   }
 
-  receivedData(fromClientId, dataSource, dataType, data, source) {
+  receivedData(fromClientId, dataType, data, source) {
     if (this.dataChannelSubs.hasOwnProperty(dataType)) {
       this.dataChannelSubs[dataType](fromClientId, dataType, data, source);
     } else {

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -65,8 +65,8 @@ class NetworkEntities {
     if (this.hasEntity(networkId)) {
       this.entities[networkId].components.networked.networkUpdate(entityData);
     } else if (entityData.isFirstSync) {
-      if (NAF.options.ignoreUnreliableFirstSyncs && source !== "reliable") {
-        NAF.log.write('Ignoring first sync from unreliable source', source);
+      if (NAF.options.firstSyncSource && source !== NAF.options.firstSyncSource) {
+        NAF.log.write('Ignoring first sync from disallowed source', source);
       } else {
         this.receiveFirstUpdateFromEntity(entityData);
       }

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -59,13 +59,17 @@ class NetworkEntities {
     entity.firstUpdateData = entityData;
   }
 
-  updateEntity(client, dataType, entityData) {
+  updateEntity(client, dataType, entityData, source) {
     var networkId = entityData.networkId;
 
     if (this.hasEntity(networkId)) {
       this.entities[networkId].components.networked.networkUpdate(entityData);
     } else if (entityData.isFirstSync) {
-      this.receiveFirstUpdateFromEntity(entityData);
+      if (NAF.options.ignoreUnreliableFirstSyncs && source !== "reliable") {
+        NAF.log.write('Ignoring first sync from unreliable source', source);
+      } else {
+        this.receiveFirstUpdateFromEntity(entityData);
+      }
     }
   }
 

--- a/src/options.js
+++ b/src/options.js
@@ -2,5 +2,6 @@ var options = {
   debug: false,
   updateRate: 15, // How often network components call `sync`
   useLerp: true, // lerp position, rotation, and scale components on networked entities.
+  ignoreUnreliableFirstSyncs: false, // Set to true if you want to ignore first sync updates from unreliable channels.
 };
 module.exports = options;

--- a/src/options.js
+++ b/src/options.js
@@ -2,6 +2,6 @@ var options = {
   debug: false,
   updateRate: 15, // How often network components call `sync`
   useLerp: true, // lerp position, rotation, and scale components on networked entities.
-  ignoreUnreliableFirstSyncs: false, // Set to true if you want to ignore first sync updates from unreliable channels.
+  firstSyncSource: null, // If specified, only allow first syncs from this source.
 };
 module.exports = options;

--- a/tests/unit/NetworkEntities.test.js
+++ b/tests/unit/NetworkEntities.test.js
@@ -149,6 +149,9 @@ suite('NetworkEntities', function() {
   })
 
   suite('updateEntity', function() {
+    teardown(function() {
+      NAF.options.firstSyncSource = null;
+    });
 
     test('first update creates new entity', sinon.test(function() {
       var mockEl = document.createElement('a-entity');
@@ -176,6 +179,17 @@ suite('NetworkEntities', function() {
       entityData.parent = 'non-existent-parent';
 
       entities.updateEntity('client', 'u', entityData);
+
+      assert.isFalse(entities.createRemoteEntity.calledWith(entityData));
+    }));
+
+    test('first update ignored from disallowed source', sinon.test(function() {
+      var mockEl = document.createElement('a-entity');
+      this.stub(entities, 'createRemoteEntity').returns(mockEl);
+
+      NAF.options.firstSyncSource = 'allowed-source';
+
+      entities.updateEntity('client', 'u', entityData, 'disallowed-source');
 
       assert.isFalse(entities.createRemoteEntity.calledWith(entityData));
     }));


### PR DESCRIPTION
Goes with https://github.com/mozilla/naf-janus-adapter/pull/74

We want to be able to ignore first sync messages from unreliable sources, so that we can enforce authoritative messages from the Hubs phoenix channel.