### PR TITLE
Perform global network tick for batched updates

### DIFF
--- a/src/NetworkConnection.js
+++ b/src/NetworkConnection.js
@@ -1,5 +1,5 @@
 /* global NAF */
-var ReservedDataType = { Update: 'u', Remove: 'r' };
+var ReservedDataType = { Update: 'u', UpdateMulti: 'um', Remove: 'r' };
 
 class NetworkConnection {
 
@@ -20,6 +20,9 @@ class NetworkConnection {
 
     this.dataChannelSubs[ReservedDataType.Update]
         = this.entities.updateEntity.bind(this.entities);
+
+    this.dataChannelSubs[ReservedDataType.UpdateMulti]
+        = this.entities.updateEntityMulti.bind(this.entities);
 
     this.dataChannelSubs[ReservedDataType.Remove]
         = this.entities.removeRemoteEntity.bind(this.entities);

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -59,6 +59,12 @@ class NetworkEntities {
     entity.firstUpdateData = entityData;
   }
 
+  updateEntityMulti(client, dataType, entityDatas, source) {
+    for (let i = 0, l = entityDatas.d.length; i < l; i++) {
+      this.updateEntity(client, 'u', entityDatas.d[i], source);
+    }
+  }
+
   updateEntity(client, dataType, entityData, source) {
     var networkId = entityData.networkId;
 

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -19,8 +19,8 @@ function defaultRequiresUpdate() {
 
 AFRAME.registerSystem("networked", {
   init() {
-    this.updateNextSyncTime();
     this.components = [];
+    this.nextSyncTime = 0;
   },
 
   register(component) {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -63,11 +63,11 @@ AFRAME.registerSystem("networked", {
   })(),
 
   updateNextSyncTime() {
-    this.nextSyncTime = this.el.sceneEl.clock.elapsedTime + 1 / NAF.options.updateRate;
+    this.nextSyncTime = this.el.clock.elapsedTime + 1 / NAF.options.updateRate;
   },
 
   needsToSync() {
-    return this.el.sceneEl.clock.elapsedTime >= this.nextSyncTime;
+    return this.el.clock.elapsedTime >= this.nextSyncTime;
   }
 });
 

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -39,25 +39,26 @@ AFRAME.registerSystem("networked", {
     const data = { d: [] };
 
     return function() {
-      if (this.needsToSync() && NAF.connection.adapter) {
-        for (let i = 0, l = this.components.length; i < l; i++) {
-          const c = this.components[i];
-          if (!c.isMine()) continue;
-          if (!c.el.parentElement) continue;
+      if (!NAF.connection.adapter) return;
+      if (!this.needsToSync()) return;
 
-          const syncData = this.components[i].syncDirty();
-          if (!syncData) continue;
+      for (let i = 0, l = this.components.length; i < l; i++) {
+        const c = this.components[i];
+        if (!c.isMine()) continue;
+        if (!c.el.parentElement) continue;
 
-          data.d.unshift(syncData);
-        }
+        const syncData = this.components[i].syncDirty();
+        if (!syncData) continue;
 
-        if (data.d.length > 0) {
-          NAF.connection.broadcastData('um', data);
-          data.d.length = 0;
-        }
-
-        this.updateNextSyncTime();
+        data.d.unshift(syncData);
       }
+
+      if (data.d.length > 0) {
+        NAF.connection.broadcastData('um', data);
+        data.d.length = 0;
+      }
+
+      this.updateNextSyncTime();
     };
   })(),
 

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -142,7 +142,7 @@ AFRAME.registerComponent('networked', {
 
     document.body.dispatchEvent(this.entityCreatedEvent());
     this.el.dispatchEvent(new CustomEvent('instantiated', {detail: {el: this.el}}));
-    this.el.system.register(this);
+    this.el.sceneEl.systems.networked.register(this);
   },
 
   attachTemplateToLocal: function() {
@@ -505,7 +505,7 @@ AFRAME.registerComponent('networked', {
       }
     }
     document.body.dispatchEvent(this.entityRemovedEvent(this.data.networkId));
-    this.el.system.deregister(this);
+    this.el.sceneEl.systems.networked.deregister(this);
   },
 
   entityCreatedEvent() {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -36,11 +36,12 @@ AFRAME.registerSystem("networked", {
   },
 
   tick: (function() {
-    const data = { d: [] };
 
     return function() {
       if (!NAF.connection.adapter) return;
       if (this.el.clock.elapsedTime < this.nextSyncTime) return;
+
+      const data = { d: [] };
 
       for (let i = 0, l = this.components.length; i < l; i++) {
         const c = this.components[i];
@@ -59,7 +60,6 @@ AFRAME.registerSystem("networked", {
 
       if (data.d.length > 0) {
         NAF.connection.broadcastData('um', data);
-        data.d.length = 0;
       }
 
       this.updateNextSyncTime();

--- a/tests/unit/NetworkConnection.test.js
+++ b/tests/unit/NetworkConnection.test.js
@@ -12,6 +12,7 @@ suite('NetworkConnection', function() {
     this.completeSync = sinon.stub();
     this.removeEntitiesOfClient = sinon.stub();
     this.updateEntity = sinon.stub();
+    this.updateEntityMulti = sinon.stub();
     this.removeRemoteEntity = sinon.stub();
     this.removeEntity = sinon.stub();
   }

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -180,6 +180,7 @@ suite('networked', function() {
       }] };
 
       networked.init();
+      networkedSystem.init();
 
       // Force initial sync instead of waiting on onConnected
       networked.syncAll();
@@ -198,7 +199,7 @@ suite('networked', function() {
 
       networkedSystem.tick();
 
-      assert.isTrue(networked.updateNextSyncTime.calledOnce);
+      assert.isTrue(networkedSystem.updateNextSyncTime.calledOnce);
     }));
   });
 

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -165,7 +165,7 @@ suite('networked', function() {
       this.stub(naf.utils, 'createNetworkId').returns('network1');
       this.stub(naf.connection, 'broadcastData');
 
-      var expected = {
+      var expected = { d: [{
         networkId: 'network1',
         creator: 'owner1',
         owner: 'owner1',
@@ -177,7 +177,7 @@ suite('networked', function() {
           1: { x: 9, y: 8, z: 7 }
         },
         isFirstSync: false
-      };
+      }] };
 
       networked.init();
 
@@ -186,15 +186,15 @@ suite('networked', function() {
 
       networked.el.setAttribute("rotation", { x: 9, y: 8, z: 7 });
 
-      networked.syncDirty();
+      networkedSystem.tick();
 
-      var called = naf.connection.broadcastData.calledWithExactly('u', expected);
+      var called = naf.connection.broadcastData.calledWithExactly('um', expected);
       assert.isTrue(called, `called with ${JSON.stringify(naf.connection.broadcastData.getCall(0).args[1])}, expected ${JSON.stringify(expected)}`);
     }));
 
     test('sets next sync time', sinon.test(function() {
       this.stub(naf.connection, 'broadcastData');
-      this.spy(networked, 'updateNextSyncTime');
+      this.spy(networkedSystem, 'updateNextSyncTime');
 
       networked.syncDirty();
 

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -196,7 +196,7 @@ suite('networked', function() {
       this.stub(naf.connection, 'broadcastData');
       this.spy(networkedSystem, 'updateNextSyncTime');
 
-      networked.syncDirty();
+      networkedSystem.tick();
 
       assert.isTrue(networked.updateNextSyncTime.calledOnce);
     }));

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -9,6 +9,7 @@ suite('networked', function() {
   var scene;
   var entity;
   var networked;
+  var networkedSystem;
 
   function initScene(done) {
     var opts = {
@@ -26,6 +27,7 @@ suite('networked', function() {
     initScene(function() {
       entity = document.querySelector('#test-entity');
       networked = entity.components['networked'];
+      networkedSystem = scene.systems['networked'];
       networked.data.networkId = '';
       done();
     });
@@ -107,10 +109,10 @@ suite('networked', function() {
 
     test('syncs if need to', sinon.test(function() {
       this.stub(networked, 'syncDirty');
-      networked.el.sceneEl.clock.elapsedTime = 4;
-      networked.nextSyncTime = 4;
+      networkedSystem.el.clock.elapsedTime = 4;
+      networkedSystem.nextSyncTime = 4;
 
-      networked.tick();
+      networkedSystem.tick();
 
       assert.isTrue(networked.syncDirty.calledOnce);
     }));
@@ -154,15 +156,6 @@ suite('networked', function() {
       var called = naf.connection.broadcastDataGuaranteed.calledWithExactly('u', expected);
 
       assert.isTrue(called);
-    }));
-
-    test('sets next sync time', sinon.test(function() {
-      this.stub(naf.connection, 'broadcastDataGuaranteed');
-      this.spy(networked, 'updateNextSyncTime');
-
-      networked.syncAll();
-
-      assert.isTrue(networked.updateNextSyncTime.calledOnce);
     }));
   });
 

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -179,14 +179,15 @@ suite('networked', function() {
         isFirstSync: false
       }] };
 
-      networked.init();
       networkedSystem.init();
+      networked.init();
 
       // Force initial sync instead of waiting on onConnected
       networked.syncAll();
 
       networked.el.setAttribute("rotation", { x: 9, y: 8, z: 7 });
 
+      networkedSystem.el.clock.elapsedTime = 4;
       networkedSystem.tick();
 
       var called = naf.connection.broadcastData.calledWithExactly('um', expected);
@@ -197,6 +198,7 @@ suite('networked', function() {
       this.stub(naf.connection, 'broadcastData');
       this.spy(networkedSystem, 'updateNextSyncTime');
 
+      networkedSystem.init();
       networkedSystem.tick();
 
       assert.isTrue(networkedSystem.updateNextSyncTime.calledOnce);


### PR DESCRIPTION
Moves the dirty sync update cycle into a shared `networked` system, and adds a new message type which sends the aggregated dirty data into a single broadcast.