### PR TITLE
Set element id on network init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ jspm_packages
 
 # MacOS
 .DS_Store
-**Icon?
 
 # Testing suites
 errorShots

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -20,8 +20,6 @@ class NetworkEntities {
     var networkId = entityData.networkId;
     var el = NAF.schemas.getCachedTemplate(entityData.template);
 
-    el.setAttribute('id', 'naf-' + networkId);
-
     this.initPosition(el, entityData.components);
     this.initRotation(el, entityData.components);
     this.addNetworkComponent(el, entityData);
@@ -132,8 +130,7 @@ class NetworkEntities {
   }
 
   addEntityToParent(entity, parentId) {
-    var parentEl = document.getElementById('naf-' + parentId);
-    parentEl.appendChild(entity);
+    this.entities[parentId].appendChild(entity);
   }
 
   addEntityToSceneRoot(el) {

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -118,8 +118,17 @@ AFRAME.registerComponent('networked', {
 
     this.initNetworkParent();
 
+    let networkId;
+
     if (this.data.networkId === '') {
-      this.el.setAttribute(this.name, {networkId: NAF.utils.createNetworkId()});
+      networkId = NAF.utils.createNetworkId()
+      this.el.setAttribute(this.name, {networkId});
+    } else {
+      networkId = this.data.networkId;
+    }
+
+    if (!this.el.id) {
+      this.el.setAttribute('id', 'naf-' + networkId);
     }
 
     if (wasCreatedByNetwork) {

--- a/tests/unit/networked.test.js
+++ b/tests/unit/networked.test.js
@@ -16,7 +16,7 @@ suite('networked', function() {
       assets: [
         "<template id='t1'><a-entity><a-entity class='template-child'></a-entity></a-entity></template>"
       ],
-      entity: '<a-entity id="test-entity" networked="template:#t1" position="1 2 3" rotation="4 3 2"><a-box></a-box></a-entity>'
+      entity: '<a-entity networked="template:#t1" position="1 2 3" rotation="4 3 2"><a-box></a-box></a-entity>'
     };
     scene = helpers.sceneFactory(opts);
     naf.utils.whenEntityLoaded(scene, done);
@@ -25,7 +25,7 @@ suite('networked', function() {
   setup(function(done) {
     naf.connection.setNetworkAdapter(new helpers.MockNetworkAdapter());
     initScene(function() {
-      entity = document.querySelector('#test-entity');
+      entity = document.querySelector('a-entity');
       networked = entity.components['networked'];
       networkedSystem = scene.systems['networked'];
       networked.data.networkId = '';
@@ -50,13 +50,15 @@ suite('networked', function() {
 
   suite('init', function() {
 
-    test('sets networkId', sinon.test(function() {
+    test('sets networkId and element id', sinon.test(function() {
       this.stub(naf.utils, 'createNetworkId').returns('nid1');
 
+      networked.el.id = ''
       networked.init();
 
       var result = networked.data.networkId;
       assert.equal(result, 'nid1');
+      assert.equal(entity.id, 'naf-nid1');
     }));
 
     test('retains networkId after component update', sinon.test(function() {


### PR DESCRIPTION
Previously NAF would only set the `id` of the DOM element when spawning a new networked entity. The result is that any code relying upon the `id` being set on a networked DOM element would fail unless the sender side had also explicitly set an id. This updates things so that the DOM element id always reflects the networked id. Note that this requires all querying against the `id` of the element be deferred until after `init` has completed.