### PR TITLE
Owned entities persist after creator leaves

### DIFF
--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -163,7 +163,7 @@ class NetworkEntities {
         let persists;
         const component = this.entities[id].getAttribute('networked');
         if (component && component.persistent) {
-          persists = NAF.utils.takeOwnership(this.entities[id]);
+          persists = NAF.utils.isMine(this.entities[id]) || NAF.utils.takeOwnership(this.entities[id]);
         }
         if (!persists) {
           var entity = this.removeEntity(id);


### PR DESCRIPTION
Fixes https://github.com/mozilla/hubs/issues/1789 .
Since `takeOwnership` returns `false` when the entity `isMine`, the `owner` of the pinned object (often the person who pinned the object in the first place) accidentally removes the entity when its creator leaves.