### PR TITLE
Check if owner is still connected when processing firstSync messages

### DIFF
--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -69,7 +69,7 @@ class NetworkEntities {
     if (NAF.options.syncSource && source !== NAF.options.syncSource) return;
     var networkId = entityData.networkId;
 
-    const entityOwnerActive = NAF.connection.activeDataChannels[entityData.owner] === false;
+    const entityOwnerActive = NAF.connection.hasActiveDataChannel(entityData.ownerId);
     if (this.hasEntity(networkId)) {
       this.entities[networkId].components.networked.networkUpdate(entityData);
     } else if (entityData.isFirstSync && entityOwnerActive) {

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -69,9 +69,10 @@ class NetworkEntities {
     if (NAF.options.syncSource && source !== NAF.options.syncSource) return;
     var networkId = entityData.networkId;
 
+    const entityOwnerActive = NAF.connection.activeDataChannels[entityData.owner] === false;
     if (this.hasEntity(networkId)) {
       this.entities[networkId].components.networked.networkUpdate(entityData);
-    } else if (entityData.isFirstSync) {
+    } else if (entityData.isFirstSync && entityOwnerActive) {
       if (NAF.options.firstSyncSource && source !== NAF.options.firstSyncSource) {
         NAF.log.write('Ignoring first sync from disallowed source', source);
       } else {

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -69,10 +69,9 @@ class NetworkEntities {
     if (NAF.options.syncSource && source !== NAF.options.syncSource) return;
     var networkId = entityData.networkId;
 
-    const entityOwnerActive = NAF.connection.hasActiveDataChannel(entityData.owner);
     if (this.hasEntity(networkId)) {
       this.entities[networkId].components.networked.networkUpdate(entityData);
-    } else if (entityData.isFirstSync && entityOwnerActive) {
+    } else if (entityData.isFirstSync && NAF.connection.hasActiveDataChannel(entityData.owner)) {
       if (NAF.options.firstSyncSource && source !== NAF.options.firstSyncSource) {
         NAF.log.write('Ignoring first sync from disallowed source', source);
       } else {

--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -69,7 +69,7 @@ class NetworkEntities {
     if (NAF.options.syncSource && source !== NAF.options.syncSource) return;
     var networkId = entityData.networkId;
 
-    const entityOwnerActive = NAF.connection.hasActiveDataChannel(entityData.ownerId);
+    const entityOwnerActive = NAF.connection.hasActiveDataChannel(entityData.owner);
     if (this.hasEntity(networkId)) {
       this.entities[networkId].components.networked.networkUpdate(entityData);
     } else if (entityData.isFirstSync && entityOwnerActive) {


### PR DESCRIPTION
Explicitly check if the owner of an entity being `firstSync`'d is still connected to prevent instantiation after disconnect. This fixes one case of "stuck" avatars where the avatar of a user can be re-instatiated after they leave.