### PR TITLE
Fix/disconnected owner first sync

### DIFF
--- a/src/NetworkEntities.js
+++ b/src/NetworkEntities.js
@@ -71,7 +71,7 @@ class NetworkEntities {
 
     if (this.hasEntity(networkId)) {
       this.entities[networkId].components.networked.networkUpdate(entityData);
-    } else if (entityData.isFirstSync && NAF.connection.hasActiveDataChannel(entityData.owner)) {
+    } else if (entityData.isFirstSync && NAF.connection.activeDataChannels[entityData.owner] !== false) {
       if (NAF.options.firstSyncSource && source !== NAF.options.firstSyncSource) {
         NAF.log.write('Ignoring first sync from disallowed source', source);
       } else {


### PR DESCRIPTION
Explicitly check if the owner of an entity being firstSync'd is still connected to prevent instantiation after disconnect. This fixes one case of "stuck" avatars where the avatar of a user can be re-instatiated after they leave.