### PR TITLE
Check validity of transform data

### DIFF
--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -17,6 +17,46 @@ function defaultRequiresUpdate() {
   };
 }
 
+function isValidVector3(v) {
+  return !!(
+    v.isVector3 &&
+    !isNaN(v.x) &&
+    !isNaN(v.y) &&
+    !isNaN(v.z) &&
+    v.x !== null &&
+    v.y !== null &&
+    v.z !== null
+  );
+}
+function isValidQuaternion(q) {
+  return !!(
+    q.isQuaternion &&
+    !isNaN(q.x) &&
+    !isNaN(q.y) &&
+    !isNaN(q.z) &&
+    !isNaN(q.w) &&
+    q.x !== null &&
+    q.y !== null &&
+    q.z !== null &&
+    q.w !== null
+  );
+}
+
+var throttle = (function () {
+  var previousLogTime = 0;
+  return function throttle(f, milliseconds) {
+    var now = Date.now();
+    if (now - previousLogTime > milliseconds) {
+      previousLogTime = now;
+      f();
+    }
+  };
+})();
+
+function warnOnInvalidNetworkUpdate() {
+  NAF.log.warn(`Received invalid network update.`);
+}
+
 AFRAME.registerSystem("networked", {
   init() {
     // An array of "networked" component instances.
@@ -257,14 +297,26 @@ AFRAME.registerComponent('networked', {
         var object3D = bufferInfo.object3D;
         var componentNames = bufferInfo.componentNames;
         buffer.update(dt);
-        if (componentNames.includes('position')) {
-          object3D.position.copy(buffer.getPosition());
+        if (componentNames.includes("position")) {
+          const position = buffer.getPosition();
+          if (!isValidVector3(position)) {
+            throttle(warnOnInvalidNetworkUpdate, 5);
+          }
+          isValidVector3(position) && object3D.position.copy(position);
         }
-        if (componentNames.includes('rotation')) {
-          object3D.quaternion.copy(buffer.getQuaternion());
+        if (componentNames.includes("rotation")) {
+          const quaternion = buffer.getQuaternion();
+          if (!isValidQuaternion(quaternion)) {
+            throttle(warnOnInvalidNetworkUpdate, 5);
+          }
+          isValidQuaternion(quaternion) && object3D.quaternion.copy(quaternion);
         }
-        if (componentNames.includes('scale')) {
-          object3D.scale.copy(buffer.getScale());
+        if (componentNames.includes("scale")) {
+          const scale = buffer.getScale();
+          if (!isValidVector3(scale)) {
+            throttle(warnOnInvalidNetworkUpdate, 5);
+          }
+          isValidVector3(scale) && object3D.scale.copy(scale);
         }
       }
     }

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -300,21 +300,21 @@ AFRAME.registerComponent('networked', {
         if (componentNames.includes("position")) {
           const position = buffer.getPosition();
           if (!isValidVector3(position)) {
-            throttle(warnOnInvalidNetworkUpdate, 5);
+            throttle(warnOnInvalidNetworkUpdate, 5000);
           }
           isValidVector3(position) && object3D.position.copy(position);
         }
         if (componentNames.includes("rotation")) {
           const quaternion = buffer.getQuaternion();
           if (!isValidQuaternion(quaternion)) {
-            throttle(warnOnInvalidNetworkUpdate, 5);
+            throttle(warnOnInvalidNetworkUpdate, 5000);
           }
           isValidQuaternion(quaternion) && object3D.quaternion.copy(quaternion);
         }
         if (componentNames.includes("scale")) {
           const scale = buffer.getScale();
           if (!isValidVector3(scale)) {
-            throttle(warnOnInvalidNetworkUpdate, 5);
+            throttle(warnOnInvalidNetworkUpdate, 5000);
           }
           isValidVector3(scale) && object3D.scale.copy(scale);
         }

--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -299,24 +299,27 @@ AFRAME.registerComponent('networked', {
         buffer.update(dt);
         if (componentNames.includes("position")) {
           const position = buffer.getPosition();
-          if (!isValidVector3(position)) {
+          if (isValidVector3(position)) {
+            object3D.position.copy(position);
+          } else {
             throttle(warnOnInvalidNetworkUpdate, 5000);
           }
-          isValidVector3(position) && object3D.position.copy(position);
         }
         if (componentNames.includes("rotation")) {
           const quaternion = buffer.getQuaternion();
-          if (!isValidQuaternion(quaternion)) {
+          if (isValidQuaternion(quaternion)) {
+            object3D.quaternion.copy(quaternion);
+          } else {
             throttle(warnOnInvalidNetworkUpdate, 5000);
           }
-          isValidQuaternion(quaternion) && object3D.quaternion.copy(quaternion);
         }
         if (componentNames.includes("scale")) {
           const scale = buffer.getScale();
-          if (!isValidVector3(scale)) {
+          if (isValidVector3(scale)) {
+            object3D.scale.copy(scale);
+          } else {
             throttle(warnOnInvalidNetworkUpdate, 5000);
           }
-          isValidVector3(scale) && object3D.scale.copy(scale);
         }
       }
     }


### PR DESCRIPTION
Fixes the common / immediate impact of https://github.com/mozilla/hubs/issues/3355

 If we are concerned about this for other networked properties, we should build validation into all of them. This only addresses `position`/`quaternion`/`scale` updates.

We should make sure this does not slow down the client.