### PR TITLE
update examples to latest aframe and use open-easyrtc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Networked-Aframe
 
 **Multi-user VR on the Web**
 
-Write full-featured multi-user VR experiences entirely in HTML.
+A framework for writing multi-user VR apps in HTML and JS.
 
-Built on top of the wonderful [A-Frame](https://aframe.io/).
+Built on top of [A-Frame](https://aframe.io/).
 
 <div>
   <a href="#features">Features</a>
@@ -31,13 +31,11 @@ Built on top of the wonderful [A-Frame](https://aframe.io/).
 
 Features
 --------
-* Includes everything you need to create multi-user WebVR apps and games.
 * Support for WebRTC and/or WebSocket connections.
 * Voice chat. Audio streaming to let your users talk in-app (WebRTC only).
 * Bandwidth sensitive. Only send network updates when things change.
+* Cross-platform. Works on all modern Desktop and Mobile browsers. Oculus Rift, Oculus Quest, HTC Vive and Google Cardboard + Daydream support.
 * Extendable. Sync any A-Frame component, including your own, without changing the component code at all.
-* Cross-platform. Works on all modern Desktop and Mobile browsers. Oculus Rift, HTC Vive and Google Cardboard + Daydream support.
-* Firebase WebRTC signalling support
 
 
 Getting Started
@@ -52,7 +50,7 @@ To run the examples on your own PC:
  ```sh
 git clone https://github.com/networked-aframe/networked-aframe.git  # Clone the repository.
 cd networked-aframe
-npm install && npm run easyrtc-install  # Install dependencies.
+npm install  # Install dependencies.
 npm run dev  # Start the local development server.
 ```
 With the server running, browse the examples at `http://localhost:8080`. Open another browser tab and point it to the same URL to see the other client.
@@ -66,9 +64,9 @@ Basic Example
 <html>
   <head>
     <title>My Networked-Aframe Scene</title>
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="easyrtc/easyrtc.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js"></script>
   </head>
   <body>
@@ -220,6 +218,7 @@ Templates must only have one root element. When `attachTemplateToLocal` is set t
 | -------- | ------------ | --------------
 | template  | A css selector to a template tag stored in `<a-assets>` | ''
 | attachTemplateToLocal  | Does not attach the template for the local user when set to false. This is useful when there is different behavior locally and remotely. | true
+| persistent | On remote owner disconnect, attempts to take ownership of persistent entities rather than delete them | false
 
 
 ### Deleting Networked Entities
@@ -267,8 +266,8 @@ To sync nested templates setup your HTML nodes like so:
 ```HTML
 <a-entity id="player" networked="template:#player-template;attachTemplateToLocal:false;" wasd-controls>
   <a-entity camera look-controls networked="template:#head-template;attachTemplateToLocal:false;"></a-entity>
-  <a-entity hand-controls="left" networked="template:#left-hand-template"></a-entity>
-  <a-entity hand-controls="right" networked="template:#right-hand-template"></a-entity>
+  <a-entity hand-controls="hand:left" networked="template:#left-hand-template"></a-entity>
+  <a-entity hand-controls="hand:right" networked="template:#right-hand-template"></a-entity>
 </a-entity>
 ```
 
@@ -421,9 +420,11 @@ Help and More Information
 * [Getting started tutorial](https://github.com/networked-aframe/networked-aframe/blob/master/docs/getting-started-local.md)
 * [Edit live example on glitch.com](https://glitch.com/~networked-aframe)
 * [Live demo site](http://haydenlee.io/networked-aframe)
+* [Networked-Aframe Adapters](https://github.com/networked-aframe)
 * [A-Frame](https://aframe.io/)
-* [WebVR](https://webvr.info/)
-* [EasyRTC WebRTC library](http://www.easyrtc.com/)
+* [WebXR](https://immersiveweb.dev)
+* [Open EasyRTC WebRTC library](https://github.com/open-easyrtc/open-easyrtc)
+* [Hayden Lee, NAF Creator and Maintainer](https://twitter.com/haydenlee37)
 * Bugs and requests can be filed on [GitHub Issues](https://github.com/networked-aframe/networked-aframe/issues)
 
 
@@ -452,13 +453,6 @@ Roadmap
 * [Add your suggestions](https://github.com/networked-aframe/networked-aframe/issues)
 
 Interested in contributing? [Open an issue](https://github.com/networked-aframe/networked-aframe/issues) or send a pull request.
-
-
-Warning
---------
-
-NAF is not supported on nodejs version 7.2.0. Please use a different version of nodejs.
-
 
 
 License

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Follow [the NAF Getting Started tutorial](https://github.com/networked-aframe/ne
 To run the examples on your own PC:
 
  ```sh
-git clone https://github.com/networked-aframe/networked-aframe.git  # Clone the repository.
+git clone https://github.com/MozillaReality/networked-aframe.git  # Clone the repository.
 cd networked-aframe
 npm install  # Install dependencies.
 npm run dev  # Start the local development server.
@@ -67,7 +67,7 @@ Basic Example
     <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
-    <script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js"></script>
+    <script src="/build.js"></script>
   </head>
   <body>
     <a-scene networked-scene>

--- a/docs/getting-started-local.md
+++ b/docs/getting-started-local.md
@@ -1,8 +1,8 @@
 # Getting started with Networked-Aframe
 
-Hello friends! This tutorial will show you how to write your very first multi-user virtual reality experience on the web.
+This tutorial will show you how to write a multi-user virtual reality experience on the web.
 
-You might be thinking: wait you can do VR on the web? And the answer is yes! Using the [WebVR standard](https://webvr.info/) and an awesome library called [A-Frame](https://aframe.io), VR on the web is actually really easy and evolving rapidly. Your second question is then: wait to do multi-user won't I have to know all about servers and complicated networking protocols? Answer: not anymore! The recently released [Networked-Aframe](https://github.com/networked-aframe/networked-aframe) (NAF for short) has you covered. NAF hides away a lot of the networking complexity, allowing you to write multi-user VR apps entirely in HTML.
+You might be thinking: wait you can do VR on the web? And the answer is yes! Using the [WebXR standard](https://github.com/immersive-web/webxr) and an awesome library called [A-Frame](https://aframe.io), VR on the web is actually really easy and evolving rapidly. Your second question is then: wait to do multi-user won't I have to know all about servers and complicated networking protocols? Answer: not anymore! The recently released [Networked-Aframe](https://github.com/networked-aframe/networked-aframe) (NAF for short) has you covered. NAF hides the networking complexity, allowing you to write multi-user VR apps with the tools you're familiar with.
 
 This tutorial goes through how to setup a Networked-Aframe experience from scratch, however if you'd like to get started writing your app with no fuss, remix this project on Glitch and get right to it:
 
@@ -36,7 +36,7 @@ Now let's setup the required dependencies. Create a file called `package.json` a
   },
   "author": "YOUR_NAME",
   "dependencies": {
-    "networked-aframe": "^0.5.0"
+    "networked-aframe": "^0.7.0"
   }
 }
 ```
@@ -72,15 +72,13 @@ Let's run the default server and start playing with the examples. From your proj
 node ./server/easyrtc-server.js
 ```
 
-
-
 You'll notice the `package.json` has a shortcut to start the server that you can use by running:
 
 ```sh
 npm start
 ```
 
-Now that the server's running you can fire up your favorite web browser (as long as its the latest Chrome or Firefox) and enter this URL:
+Now that the server's running you can fire up a [web browser that supports WebXR](https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API#Browser_compatibility) and enter this URL:
 
 ```
 http://localhost:8080
@@ -108,8 +106,8 @@ Here's the template we'll start with:
 ```html
 <html>
   <head>
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
     <script src="easyrtc/easyrtc.js"></script>
     <script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js"></script>
   </head>
@@ -243,7 +241,7 @@ To spruce up your world add the following HTML tags:
 ```html
 <!-- Add to bottom of the a-assets tag -->
 <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-<img id="sky" src="https://img.gs/bbdkhfbzkk/2048x2048,stretch/http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+<img id="sky" src="https://img.gs/bbdkhfbzkk/2048x2048,stretch/https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
 <!-- Add to bottom of a-scene tag -->
 <a-entity position="0 0 0"
@@ -278,6 +276,17 @@ By default NAF uses WebSockets to send packets to other users. This follows a cl
 
 NAF has built in voice chat when you're using WebRTC. Change `adapter` and `audio` properties of the `networked-scene` component to `easyrtc` and `true` respectively and your users will be able to speak to each other. This is a little hard to test locally because the audio feedback will destroy your ears, so try it with headphones and you'll hear your voice being echoed back to you without the feedback. Note: in order for audio streaming to work on a hosted server you'll need to be using HTTPS. I'm planning on writing a follow-up tutorial to this one that will explain how to deploy NAF to a live server, including how to setup HTTPS really easily using [Certbot](https://certbot.eff.org/).
 
+**Using HTTPS locally**:
+
+To serve the site over HTTPS locally, you can install and run [ngrok](https://ngrok.com/).
+ngrok allows you to expose a web server running on your local machine to the internet. Just tell ngrok what port your web server is listening on.
+
+```bash
+ngrok http 8080
+```
+You can then visit the outputted `https://<x>.ngrok.io` domain.
+
+I'm planning on writing a follow-up tutorial to this one that will explain how to deploy NAF to a live server, including how to setup HTTPS really easily using [Certbot](https://certbot.eff.org/).
 
 ### Syncing Custom Components
 

--- a/docs/getting-started-local.md
+++ b/docs/getting-started-local.md
@@ -108,8 +108,8 @@ Here's the template we'll start with:
   <head>
     <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
-    <script src="easyrtc/easyrtc.js"></script>
-    <script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
+    <script src="/build.js"></script>
   </head>
   <body>
     <a-scene></a-scene>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networked-aframe",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "description": "A web framework for building multi-user virtual reality experiences.",
   "homepage": "",
   "main": "src/index.js",
@@ -11,11 +11,10 @@
   },
   "scripts": {
     "build": "browserify src/index.js -o server/static/build.js",
-    "easyrtc-install": "cd ./node_modules/easyrtc; npm install; cd ../../;",
     "dev": "npm run build && node ./server/easyrtc-server.js",
     "dist": "webpack --config webpack.config.js && webpack -p --config webpack.prod.config.js",
     "lint": "eslint src tests *.js",
-    "prepublish": "npm run dist",
+    "prepare": "npm run dist",
     "preghpages": "npm run build && shx rm -rf gh-pages && shx mkdir gh-pages && shx cp -r examples/* gh-pages",
     "ghpages": "npm run preghpages && ghpages -p gh-pages",
     "start": "node ./server/easyrtc-server.js",
@@ -27,7 +26,7 @@
   "repository": "networked-aframe/networked-aframe",
   "dependencies": {
     "buffered-interpolation": "^0.2.5",
-    "easyrtc": "1.1.0"
+    "open-easyrtc": "2.0.5"
   },
   "devDependencies": {
     "aframe": "0.7.0",
@@ -41,7 +40,7 @@
     "chai-shallow-deep-equal": "^1.4.0",
     "chalk": "^1.1.3",
     "eslint": "^4.14.0",
-    "express": "^4.16.0",
+    "express": "^4.17.1",
     "karma": "^1.4.1",
     "karma-browserify": "^5.1.1",
     "karma-chai-shallow-deep-equal": "0.0.4",
@@ -55,12 +54,12 @@
     "mocha": "^3.2.0",
     "node-fetch": "^1.6.3",
     "semistandard": "^8.0.0",
-    "serve-static": "^1.13.0",
+    "serve-static": "^1.14.1",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0",
     "snazzy": "^6.0.0",
-    "socket.io": "^1.7.4",
-    "socket.io-client": "^1.7.4",
+    "socket.io": "^2.3.0",
+    "socket.io-client": "^2.3.0",
     "watchify": "^3.9.0",
     "webpack": "^1.13.0"
   },
@@ -76,6 +75,8 @@
     "three",
     "three.js",
     "rift",
+    "quest",
+    "webrtc",
     "social",
     "vive",
     "vr",

--- a/server/easyrtc-server.js
+++ b/server/easyrtc-server.js
@@ -3,7 +3,7 @@ var http    = require("http");              // http server core module
 var express = require("express");           // web framework external module
 var serveStatic = require('serve-static');  // serve static files
 var socketIo = require("socket.io");        // web socket external module
-var easyrtc = require("easyrtc");               // EasyRTC external module
+var easyrtc = require("open-easyrtc");               // EasyRTC external module
 
 // Set process name
 process.title = "node-easyrtc";
@@ -20,19 +20,16 @@ var webServer = http.createServer(app);
 
 // Start Socket.io so it attaches itself to Express server
 var socketServer = socketIo.listen(webServer, {"log level":1});
-
 var myIceServers = [
-  {"url":"stun:stun.l.google.com:19302"},
-  {"url":"stun:stun1.l.google.com:19302"},
-  {"url":"stun:stun2.l.google.com:19302"},
-  {"url":"stun:stun3.l.google.com:19302"}
+  {"urls":"stun:stun1.l.google.com:19302"},
+  {"urls":"stun:stun2.l.google.com:19302"},
   // {
-  //   "url":"turn:[ADDRESS]:[PORT]",
+  //   "urls":"turn:[ADDRESS]:[PORT]",
   //   "username":"[USERNAME]",
   //   "credential":"[CREDENTIAL]"
   // },
   // {
-  //   "url":"turn:[ADDRESS]:[PORT][?transport=tcp]",
+  //   "urls":"turn:[ADDRESS]:[PORT][?transport=tcp]",
   //   "username":"[USERNAME]",
   //   "credential":"[CREDENTIAL]"
   // }
@@ -76,5 +73,5 @@ var rtc = easyrtc.listen(app, socketServer, null, function(err, rtcRef) {
 
 //listen on port
 webServer.listen(port, function () {
-  console.log('listening on http://localhost:' + port);
+    console.log('listening on http://localhost:' + port);
 });

--- a/server/static/360.html
+++ b/server/static/360.html
@@ -5,8 +5,8 @@
     <title>360 Image Example — Networked-Aframe</title>
     <meta name="description" content="360 Image Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
@@ -60,7 +60,13 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template;attachTemplateToLocal:false;" camera="userHeight: 1.6" spawn-in-circle="radius:3" wasd-controls look-controls>
+      <a-entity id="player"
+        networked="template:#avatar-template;attachTemplateToLocal:false;"
+        camera
+        position="0 1.6 0"
+        spawn-in-circle="radius:3"
+        wasd-controls look-controls
+        >
         <a-sphere class="head"
           visible="false"
           random-color

--- a/server/static/a-saturday-night/index.html
+++ b/server/static/a-saturday-night/index.html
@@ -2,10 +2,10 @@
   <head>
     <!-- Forked from MozillaVR's `A Saturday Night` demo: https://github.com/aframevr/a-saturday-night -->
 
-    <script src="https://aframe.io/releases/0.6.0/aframe.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
-    <script src="../build.js"></script>
+    <script src="/build.js"></script>
 
     <script src="js/spawn-in-circle.component.js"></script>
     <script src="js/show-child.component.js"></script>
@@ -103,7 +103,7 @@
 			</a-assets>
 
 			<a-entity id="player" networked="template:#player-template;attachTemplateToLocal:false;" spawn-in-circle="radius:2;" wasd-controls show-avatar="index:0;numAvatars:4" randomize-avatar>
-			  <a-entity camera="userHeight: 1.6" look-controls networked="template:#head-template;attachTemplateToLocal:false;" class="heads" visible="false" show-child="0">
+			  <a-entity camera position="0 1.6 0" look-controls networked="template:#head-template;attachTemplateToLocal:false;" class="heads" visible="false" show-child="0">
           <a-entity class="head" gltf-model="#avatar1-head-obj"></a-entity>
           <a-entity class="head" gltf-model="#avatar2-head-obj"></a-entity>
           <a-entity class="head" gltf-model="#avatar3-head-obj"></a-entity>

--- a/server/static/a-saturday-night/js/non-vr-height.component.js
+++ b/server/static/a-saturday-night/js/non-vr-height.component.js
@@ -29,11 +29,11 @@ AFRAME.registerComponent('non-vr-height', {
 
   exitedVR: function () {
     console.log("EXITED VR");
-    this.setHeight(this.getData());
+    this.setHeight(this.data);
   },
 
   setHeight: function(height) {
-    var position = this.el.components.position.getData();
+    var position = this.el.components.position.data;
     position.y = height;
     this.el.setAttribute('position', position);
   }

--- a/server/static/a-saturday-night/js/randomize-avatar.component.js
+++ b/server/static/a-saturday-night/js/randomize-avatar.component.js
@@ -2,7 +2,7 @@ AFRAME.registerComponent('randomize-avatar', {
   schema: {},
 
   init: function() {
-  	var data = this.el.components['show-avatar'].getData();
+  	var data = this.el.components['show-avatar'].data;
   	var r = Math.floor(Math.random() * data.numAvatars);
   	data.index = r;
   	this.el.setAttribute('show-avatar', data);

--- a/server/static/a-saturday-night/js/show-avatar.component.js
+++ b/server/static/a-saturday-night/js/show-avatar.component.js
@@ -6,7 +6,7 @@ AFRAME.registerComponent('show-avatar', {
 
   update: function() {
     this.waitingToLoad = true;
-    this.showAvatar(this.getData().index);
+    this.showAvatar(this.data.index);
   },
 
   tick: function() {

--- a/server/static/a-saturday-night/js/show-child.component.js
+++ b/server/static/a-saturday-night/js/show-child.component.js
@@ -5,7 +5,7 @@ AFRAME.registerComponent('show-child', {
   },
 
   update: function() {
-    this.show(this.getData());
+    this.show(this.data);
   },
 
   show: function(index) {

--- a/server/static/adapter-test/adapter-test-receive.html
+++ b/server/static/adapter-test/adapter-test-receive.html
@@ -4,7 +4,9 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
@@ -64,9 +66,6 @@
 
     <!-- Uncomment the block corresponding to the network adapter you want to test -->
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
-    
     <a-scene embedded networked-scene="
       room: dev;
       debug: true;

--- a/server/static/adapter-test/adapter-test-send.html
+++ b/server/static/adapter-test/adapter-test-send.html
@@ -4,7 +4,9 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
@@ -42,9 +44,6 @@
 
     <!-- Uncomment the block corresponding to the network adapter you want to test -->
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
-    
     <a-scene embedded networked-scene="
       room: dev;
       debug: true;

--- a/server/static/basic-ar.html
+++ b/server/static/basic-ar.html
@@ -4,15 +4,15 @@
     <title>Basic AR Example — Networked-Aframe</title>
     <meta name="description" content="Basic AR Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
+    <script src="/build.js"></script>
+    <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
 
     <!-- AR -->
     <script src="https://rawgit.com/jeromeetienne/ar.js/master/aframe/build/aframe-ar.js"></script>
     <script>THREEx.ArToolkitContext.baseURL = 'https://rawgit.com/jeromeetienne/ar.js/master/three.js/'</script>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="easyrtc/easyrtc.js"></script>
-    <script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js"></script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
     <script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>

--- a/server/static/basic-audio.html
+++ b/server/static/basic-audio.html
@@ -4,18 +4,17 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
-
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
     <script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
     <a-scene networked-scene="
       room: basic-audio;
       debug: true;
@@ -25,13 +24,13 @@
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
         <!-- Avatar -->
         <template id="avatar-template">
-          <a-entity class="avatar">
+          <a-entity class="avatar" networked-audio-source>
             <a-sphere class="head"
               color="#ffffff"
               scale="0.45 0.5 0.4"
@@ -68,7 +67,13 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template;attachTemplateToLocal:false;" camera="userHeight: 1.6" spawn-in-circle="radius:3" wasd-controls look-controls>
+      <a-entity id="player"
+        networked="template:#avatar-template;attachTemplateToLocal:false;"
+        camera
+        position="0 1.6 0"
+        spawn-in-circle="radius:3"
+        wasd-controls look-controls
+        >
         <a-sphere class="head"
           visible="false"
           random-color

--- a/server/static/basic-events.html
+++ b/server/static/basic-events.html
@@ -4,7 +4,9 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
 
@@ -13,17 +15,14 @@
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
     <a-scene networked-scene="
       room: dev;
       debug: true;
-      adapter: wseasyrtc;
     ">
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
@@ -65,11 +64,17 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template;attachTemplateToLocal:false;" camera="userHeight: 1.6" spawn-in-circle="radius:3" wasd-controls look-controls>
-          <a-sphere class="head"
-            random-color
-            visible="false"
-          ></a-sphere>
+      <a-entity id="player"
+        networked="template:#avatar-template;attachTemplateToLocal:false;"
+        camera
+        position="0 1.6 0"
+        spawn-in-circle="radius:3"
+        wasd-controls look-controls
+        >
+        <a-sphere class="head"
+          visible="false"
+          random-color
+        ></a-sphere>
       </a-entity>
 
       <a-entity position="0 0 0"

--- a/server/static/basic.html
+++ b/server/static/basic.html
@@ -4,7 +4,9 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
 
@@ -13,8 +15,6 @@
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
     <a-scene networked-scene="
       room: dev;
       debug: true;
@@ -23,7 +23,7 @@
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
@@ -66,7 +66,13 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template;attachTemplateToLocal:false;" camera="userHeight: 1.6" spawn-in-circle="radius:3" wasd-controls look-controls>
+      <a-entity id="player"
+        networked="template:#avatar-template;attachTemplateToLocal:false;"
+        camera
+        position="0 1.6 0"
+        spawn-in-circle="radius:3"
+        wasd-controls look-controls
+        >
         <a-sphere class="head"
           visible="false"
           random-color

--- a/server/static/child-entities.html
+++ b/server/static/child-entities.html
@@ -4,7 +4,9 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
 
@@ -13,8 +15,6 @@
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
     <a-scene networked-scene="
       room: dev;
       debug: true;
@@ -23,7 +23,7 @@
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
@@ -72,7 +72,7 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template" camera="userHeight: 1.6" spawn-in-circle="radius:3" wasd-controls look-controls>
+      <a-entity id="player" networked="template:#avatar-template" position="0 1.6 0" camera spawn-in-circle="radius:3" wasd-controls look-controls>
         <a-sphere class="head"
           color="#5985ff"
           scale="0.45 0.5 0.4"

--- a/server/static/disconnect.html
+++ b/server/static/disconnect.html
@@ -4,7 +4,9 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
 
@@ -13,13 +15,11 @@
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
     <a-scene>
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
@@ -63,12 +63,16 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template" camera="userHeight: 1.6" spawn-in-circle="radius:3" wasd-controls look-controls>
+      <a-entity id="player"
+        networked="template:#avatar-template;attachTemplateToLocal:false;"
+        camera
+        position="0 1.6 0"
+        spawn-in-circle="radius:3"
+        wasd-controls look-controls
+        >
         <a-sphere class="head"
-          color="#5985ff"
-          scale="0.45 0.5 0.4"
-          random-color
           visible="false"
+          random-color
         ></a-sphere>
       </a-entity>
 

--- a/server/static/google-blocks.html
+++ b/server/static/google-blocks.html
@@ -4,8 +4,8 @@
     <title>Basic Example — Networked-Aframe</title>
     <meta name="description" content="Basic Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
@@ -23,7 +23,7 @@
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://img.gs/bbdkhfbzkk/2048x2048,stretch/http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://img.gs/bbdkhfbzkk/2048x2048,stretch/https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <a-asset-item id="raccoon-obj" src="./assets/Raccoon_Blocks/model.obj"></a-asset-item>
         <a-asset-item id="raccoon-mtl" src="./assets/Raccoon_Blocks/materials.mtl"></a-asset-item>
@@ -43,7 +43,7 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" class="heads" networked="template:#avatar-template;attachTemplateToLocal:false;" camera="userHeight: 1.6" spawn-in-circle="radius:2;" wasd-controls look-controls></a-entity>
+      <a-entity id="player" class="heads" networked="template:#avatar-template;attachTemplateToLocal:false;" camera position="0 1.6 0" spawn-in-circle="radius:2;" wasd-controls look-controls></a-entity>
 
       <!-- <a-entity light="color: #ccccff; intensity: 1; type: ambient;" visible=""></a-entity> -->
       <!-- <a-entity light="color: #ffaaff; intensity: 1.5" position="5 5 5"></a-entity> -->

--- a/server/static/js/spawn-in-circle.component.js
+++ b/server/static/js/spawn-in-circle.component.js
@@ -11,11 +11,13 @@ AFRAME.registerComponent('spawn-in-circle', {
     var circlePoint = this.randomPointOnCircle(this.data.radius, angleRad);
     var worldPoint = {x: circlePoint.x + center.x, y: center.y, z: circlePoint.y + center.z};
     el.setAttribute('position', worldPoint);
+    // console.log('world point', worldPoint);
 
     var angleDeg = angleRad * 180 / Math.PI;
     var angleToCenter = -1 * angleDeg + 90;
-    var rotationStr = '0 ' + angleToCenter + ' 0';
-    el.setAttribute('rotation', rotationStr);
+    var angleRad = THREE.Math.degToRad(angleToCenter);
+    el.object3D.rotation.set(0, angleRad, 0);
+    // console.log('angle deg', angleDeg);
   },
 
   getRandomAngleInRadians: function() {

--- a/server/static/ownership-transfer.html
+++ b/server/static/ownership-transfer.html
@@ -4,7 +4,9 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
 
     <style>
@@ -32,8 +34,6 @@
 
   </head>
   <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
     <a-scene
       networked-scene="
         room: dev;
@@ -43,7 +43,7 @@
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
@@ -91,10 +91,17 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template;attachTemplateToLocal:false;" camera="userHeight: 1.6" spawn-in-circle="radius:1" wasd-controls look-controls spawner="template:#cube-template">
+      <a-entity id="player"
+        networked="template:#avatar-template;attachTemplateToLocal:false;"
+        camera
+        position="0 1.6 0"
+        spawn-in-circle="radius:3"
+        spawner="template:#cube-template"
+        wasd-controls look-controls
+        >
         <a-sphere class="head"
-          random-color
           visible="false"
+          random-color
         ></a-sphere>
       </a-entity>
 

--- a/server/static/shooter-ar.html
+++ b/server/static/shooter-ar.html
@@ -4,15 +4,15 @@
     <title>Shooter AR Example — Networked-Aframe</title>
     <meta name="description" content="Shooter AR Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.6.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
+    <script src="/build.js"></script>
+    <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
 
     <!-- AR -->
     <script src="https://rawgit.com/jeromeetienne/ar.js/master/aframe/build/aframe-ar.js"></script>
     <script>THREEx.ArToolkitContext.baseURL = 'https://rawgit.com/jeromeetienne/ar.js/master/three.js/'</script>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="easyrtc/easyrtc.js"></script>
-    <script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js"></script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
     <script src="https://unpkg.com/aframe-particle-system-component@1.0.5/dist/aframe-particle-system-component.min.js"></script>

--- a/server/static/shooter.html
+++ b/server/static/shooter.html
@@ -4,10 +4,10 @@
     <title>Shooter Example — Networked-Aframe</title>
     <meta name="description" content="Shooter Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="easyrtc/easyrtc.js"></script>
-    <script src="build.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
+    <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
 
     <script src="https://unpkg.com/aframe-randomizer-components@^3.0.1/dist/aframe-randomizer-components.min.js"></script>
@@ -26,7 +26,7 @@
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="https://img.gs/bbdkhfbzkk/2048x2048,stretch/http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://img.gs/bbdkhfbzkk/2048x2048,stretch/https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
@@ -86,11 +86,17 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template" gun="bulletTemplate:#bullet-template" camera="userHeight: 1.6" spawn-in-circle="radius:3;" wasd-controls look-controls>
+      <a-entity id="player"
+        networked="template:#avatar-template;attachTemplateToLocal:false;"
+        camera
+        position="0 1.6 0"
+        spawn-in-circle="radius:3"
+        wasd-controls look-controls
+        gun="bulletTemplate:#bullet-template"
+        >
         <a-sphere class="head"
-          color="#5985ff"
-          random-color
           visible="false"
+          random-color
         ></a-sphere>
       </a-entity>
 

--- a/server/static/tracked-controllers.html
+++ b/server/static/tracked-controllers.html
@@ -4,8 +4,8 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
     <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
@@ -23,7 +23,7 @@
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
@@ -79,15 +79,15 @@
       </a-assets>
 
       <a-entity id="player" networked="template:#player-template;attachTemplateToLocal:false;" spawn-in-circle="radius:3" wasd-controls>
-        <a-entity camera="userHeight: 1.6" look-controls networked="template:#head-template;attachTemplateToLocal:false;">
+        <a-entity camera position="0 1.6 0" look-controls networked="template:#head-template;attachTemplateToLocal:false;">
             <a-sphere class="head"
               random-color
               visible="false"
             ></a-sphere>
         </a-entity>
 
-        <a-entity hand-controls="left" networked="template:#hand-template;"></a-entity>
-        <a-entity hand-controls="right" networked="template:#hand-template;"></a-entity>
+        <a-entity hand-controls="hand:left" networked="template:#hand-template;"></a-entity>
+        <a-entity hand-controls="hand:right" networked="template:#hand-template;"></a-entity>
       </a-entity>
 
       <a-entity position="0 0 0"

--- a/server/static/webrtc.html
+++ b/server/static/webrtc.html
@@ -4,7 +4,9 @@
     <title>Dev Example — Networked-Aframe</title>
     <meta name="description" content="Dev Example — Networked-Aframe">
 
-    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="/easyrtc/easyrtc.js"></script>
     <script src="/build.js"></script>
     <script>window.NAF || document.write('<script src="https://unpkg.com/networked-aframe/dist/networked-aframe.min.js">\x3C/script>')</script>
 
@@ -13,8 +15,6 @@
     <script src="/js/spawn-in-circle.component.js"></script>
   </head>
   <body>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.min.js"></script>
-    <script src="/easyrtc/easyrtc.js"></script>
     <a-scene networked-scene="
       room: dev;
       debug: true;
@@ -23,7 +23,7 @@
       <a-assets>
 
         <img id="grid" src="https://img.gs/bbdkhfbzkk/stretch/https://i.imgur.com/25P1geh.png" crossorigin="anonymous">
-        <img id="sky" src="http://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
+        <img id="sky" src="https://i.imgur.com/WqlqEkq.jpg" crossorigin="anonymous" />
 
         <!-- Templates -->
 
@@ -66,12 +66,18 @@
         <!-- /Templates -->
       </a-assets>
 
-      <a-entity id="player" networked="template:#avatar-template;attachTemplateToLocal:false;" camera="userHeight: 1.6" spawn-in-circle="radius:3" wasd-controls look-controls>
-        <a-sphere class="head"
-          visible="false"
-          random-color
-        ></a-sphere>
-      </a-entity>
+      <a-entity id="player"
+      networked="template:#avatar-template;attachTemplateToLocal:false;"
+      camera
+      position="0 1.6 0"
+      spawn-in-circle="radius:3"
+      wasd-controls look-controls
+      >
+      <a-sphere class="head"
+        visible="false"
+        random-color
+      ></a-sphere>
+    </a-entity>
 
       <a-entity position="0 0 0"
         geometry="primitive: plane; width: 10000; height: 10000;" rotation="-90 0 0"


### PR DESCRIPTION
First some context, we currently have the original repository https://github.com/networked-aframe/networked-aframe that doesn't have a maintainer anymore (so doing a PR there will probably not be merged because Hayden Lee's new job doesn't legally allow him to work on other projects, @haydenjameslee correct me if I'm wrong) and Mozilla's fork that is used with Hubs and dialog adapter that is inside Hubs repository.

Some history, the two repositories https://github.com/networked-aframe/networked-aframe and https://github.com/MozillaReality/networked-aframe were in sync around Jul 24, 2019.
Since then, in the Mozilla fork, there were many fixes about persistent, ownership and received data checks.
In the original repo, there was at one point a PR to update it to open-easyrtc, but Hayden Lee didn't merge it because he was working on new adapters that are now webrtc and socketio, without any other external dependency except socket.io.
The socketio doesn't support audio, the webrtc adapter is not battle tested and seems currently broken.
The easyrtc adapter code was moved to a separate repo https://github.com/networked-aframe/naf-easyrtc-adapter but no release was made.
In the meantime, new people want to try to tinker with NAF (see #networked-aframe channel on A-Frame Slack) but we don't currently have an up to date repo with latest aframe examples and a simple working adapter, this is sad. :(

So I made this PR again Mozilla's fork master branch with a subset of the changes that Hayden did in the original repo plus some more fixes with latest aframe compatibility he didn't catch and the switch to open-easyrtc for security reasons.
I didn't backport all the packages updates and eslint changes so Mozilla can merge the PR without too much review, it's mainly doc changes. I hope you can merge it.
