### PR TITLE
Add adapter guard for early disconnects

### DIFF
--- a/src/NetworkConnection.js
+++ b/src/NetworkConnection.js
@@ -208,7 +208,10 @@ class NetworkConnection {
 
   disconnect() {
     this.entities.removeRemoteEntities();
-    this.adapter.disconnect();
+
+    if (this.adapter) {
+      this.adapter.disconnect();
+    }
 
     NAF.app = '';
     NAF.room = '';


### PR DESCRIPTION
If the network connection is disconnected before the adapter has been set, the disconnect function throws an error. This occurs in Hubs when loading a closed room. I added a guard so that this error is no longer thrown.