### PR TITLE
Dirty flag optimization

### DIFF
--- a/src/components/networked.js
+++ b/src/components/networked.js
@@ -4,6 +4,8 @@ var InterpolationBuffer = require('buffered-interpolation');
 var DEG2RAD = THREE.Math.DEG2RAD;
 var OBJECT3D_COMPONENTS = ['position', 'rotation', 'scale'];
 
+const EPSILON = 0.00000000001;
+
 function defaultRequiresUpdate() {
   let cachedData = null;
 
@@ -300,8 +302,10 @@ AFRAME.registerComponent('networked', {
         if (componentNames.includes("position")) {
           const position = buffer.getPosition();
           if (isValidVector3(position)) {
-            object3D.position.copy(position);
-            object3D.matrixNeedsUpdate = true;
+            if (!object3D.position.near(position, EPSILON)) {
+              object3D.position.copy(position);
+              object3D.matrixNeedsUpdate = true;
+            }
           } else {
             throttle(warnOnInvalidNetworkUpdate, 5000);
           }
@@ -309,8 +313,10 @@ AFRAME.registerComponent('networked', {
         if (componentNames.includes("rotation")) {
           const quaternion = buffer.getQuaternion();
           if (isValidQuaternion(quaternion)) {
-            object3D.quaternion.copy(quaternion);
-            object3D.matrixNeedsUpdate = true;
+            if (!object3D.quaternion.near(quaternion, EPSILON)) {
+              object3D.quaternion.copy(quaternion);
+              object3D.matrixNeedsUpdate = true;
+            }
           } else {
             throttle(warnOnInvalidNetworkUpdate, 5000);
           }
@@ -318,8 +324,10 @@ AFRAME.registerComponent('networked', {
         if (componentNames.includes("scale")) {
           const scale = buffer.getScale();
           if (isValidVector3(scale)) {
-            object3D.scale.copy(scale);
-            object3D.matrixNeedsUpdate = true;
+            if (!object3D.scale.near(scale, EPSILON)) {
+              object3D.scale.copy(scale);
+              object3D.matrixNeedsUpdate = true;
+            }
           } else {
             throttle(warnOnInvalidNetworkUpdate, 5000);
           }


### PR DESCRIPTION
Currently `networked-aframe` always raises dirty flags if it receives `position/quaternion/scale`. But this behavior can cause unnecessary matrices updates even if remote objects don't move.

This PR optimizes dirty flag raising. Raise them only if needed by checking the diff between old and new values.

**History**

Hubs had `matrix-auto-update` component that sets Three.js Objects' `.matrixAutoUpdate` that can cause matrices update every frame. Networked objects had this component.

`matrix-auto-update` is very costly so we have removed in https://github.com/mozilla/hubs/pull/5339. At that time we raise the dirty flag in `networked-aframe` every time when it receives `position/quaternion/scale` as short-term solution.

We should further optimize them. We should raise the dirty flags only if new values have diff from old vaules.

**Alternate**

Sending new values to remotes only if local objects are moved may be another solution. It would be more efficient because of less network usage. 

Update:
[`networked-aframe` already sends only if objects are moved](https://github.com/mozilla/hubs/blob/81a0c32f6bb3677fd8400b9c8460053d30fffba9/src/network-schemas.js#L30-L41), but [we have a Hubs component that sends data to remote every 5 secs](https://github.com/mozilla/hubs/blob/master/src/components/periodic-full-syncs.js), so checking the diff on the receivers end is needed at least for now.
And if `networked-aframe` doesn't guarantee the delivery and the order, the diff check in the receivers end will be still needed (I need to check).

Update2:
I tested locally and found that [this code block](https://github.com/MozillaReality/networked-aframe/blob/master/src/components/networked.js#L301-L307) is executed every frame regardless of whether data arrivies or not. I don't think it's a good design. Ideally we should investigate the root issue but for now applying this patch as workaround may be good.